### PR TITLE
Updadate for brew's bash-completion script

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -26,8 +26,8 @@ for option in autocd globstar; do
 done;
 
 # Add tab completion for many Bash commands
-if which brew &> /dev/null && [ -f "$(brew --prefix)/share/bash-completion/bash_completion" ]; then
-	source "$(brew --prefix)/share/bash-completion/bash_completion";
+if which brew &> /dev/null && [ -f "$(brew --prefix)/etc/bash_completion" ]; then
+	source "$(brew --prefix)/etc/bash_completion";
 elif [ -f /etc/bash_completion ]; then
 	source /etc/bash_completion;
 fi;


### PR DESCRIPTION
brew currently installs bash-completion script at ```$(brew --prefix)/share/bash-completion/bash_completion```